### PR TITLE
Fix readiness check

### DIFF
--- a/sample/hello-kubernetes-java-mvn/pom.xml
+++ b/sample/hello-kubernetes-java-mvn/pom.xml
@@ -108,7 +108,7 @@
             <dependency>
                 <groupId>com.lightbend.lagom</groupId>
                 <artifactId>service-locator-akka-discovery_${scala.binary.version}</artifactId>
-                <version>0.0.2</version>
+                <version>0.0.3</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
Note this commit sets the version in the sample to 0.0.3. 

After merging, we must make sure that the tag `v0.0.03` is present on master so `dynver` can work properly.