### PR TITLE
merge once signed-off

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,20 +5,12 @@ pull_request_rules:
       - status-success=continuous-integration/travis-ci/pr
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
-      - label=merge-when-green
+      - "#review-requested=0"
       - label!=block-merge
     actions:
       merge:
         method: squash
         strict: smart
-
-  - name: Delete the merge-when-green label after merge
-    conditions:
-      - merged
-      - label=merge-when-green
-    actions:
-      label:
-        remove: [merge-when-green]
 
   - name: Delete the PR branch after merge
     conditions:


### PR DESCRIPTION
This PR changes Mergify with the following rules for automatic merge (squash): 

* merge if at least one sign-off
* all requested reviewers have signed
* build is green
* not block-merge
* nobody requested for change

If nobody is assigned as reviewer, we still need someone to come voluntarily and review it. If we ask review, for instance, two 2 maintainers, the two must come and sign-off. 

