### PR TITLE
fix scala version to all modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
     - stage: tests
       script: sbt headerCheck test:headerCheck scalafmtCheck test:scalafmtCheck test
     - stage: publish
-      script: sbt +publish
+      script: sbt publish
 
 stages:
   - name: tests

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.8"
+scalaVersion in ThisBuild := "2.12.8"
 
 val commonSettings = Seq(
   organization := "com.lightbend.lagom",


### PR DESCRIPTION
Travis build was not able to publish the artefacts because of mixed versions of Scala 2.12.x