### PR TITLE
Ported to Akka 2.5.20 and reworked schema / service name mappings

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   object Versions {
     val Lagom14 = "1.4.9"
-    val Akka = "2.5.19"
+    val Akka = "2.5.20"
     val ScalaTest = "3.0.5"
   }
 

--- a/service-locator/core/src/main/resources/reference.conf
+++ b/service-locator/core/src/main/resources/reference.conf
@@ -1,15 +1,6 @@
 
 lagom.akka.discovery {
 
-  # The regular expression used to parse the port name, port protocol and service from the service name. This will be
-  # used to extract the port and protocol so that Akka discovery can know what those parameters are. If the regular
-  # expression doesn't match, then the port and protocol will be added from the defaults, if set. The regex should
-  # define three named capturing groups (using the (?<name>X) syntax), portName, portProtocol and service. If it
-  # doesn't define such a named capturing group, or if a particular named capturing group is empty, then it will
-  # consider that part of the lookup to empty and use the defaults instead. If this regex is blank, no attempt will be
-  # made to parse the port and protocol from the name, and the defaults will be used instead.
-  service-lookup-regex = "^_(?<portName>[^\\.]+)\\._(?<portProtocol>[^\\.]+)\\.(?<service>.*)$"
-
   # When the service lookup regex fails, the defaults are used for the port and protocol.
   defaults {
 
@@ -23,33 +14,25 @@ lagom.akka.discovery {
     scheme = tcp
   }
 
-  # A mapping of port names to schemes
-  port-name-scheme-mapping {
-    http = http
-    https = https
-  }
-
   # A mapping of service names to lookup information. Each mapping should define the following:
-  # - service-name - The name of the service. If undefined, will use the same name.
-  # - port-name - The name of the port, for example, http. If undefined, will use lagom.akka.discovery.defaults.port-name
-  # - port-protocol - The protocol. If undefined, will use lagom.akka.discovery.defaults.port-protocol
-  # - scheme - The scheme to return in the URI. If undefined, will attempt to map the port-name to a scheme using
-  #   lagom.akka.discovery.port-name-scheme-mapping, and if that fails, will use lagom.akka.discover.defaults.scheme.
+  #
+  # - lookup - An alternative name for the service. This can be configured with a simple name or a SRV lookup, for exampe:
+  #   * my-service (simple name)
+  #   * my-service.default.svc.cluster.local (simple full-qualified name)
+  #   * _http._tcp.my-service (SRV)
+  #   * _http._tcp.my-service.default.svc.cluster.local (full-qualified SRV)
+  # - scheme - The scheme to return in the URI. If undefined, it will use the default scheme lagom.akka.discover.defaults.scheme.
+  #
   # For example:
   # service-name-mappings {
   #   my-service-name {
-  #     service-name = my-service.default.svc.cluster.local
-  #     port-name = http
+  #     lookup = my-service.default.svc.cluster.local
+  #     scheme = http
   #   }
   # }
   service-name-mappings {
   }
 
-  # A suffix to be appended to service names when doing lookups.
-  # Generally, this shouldn't be needed, but until https://github.com/akka/akka/issues/25825 is implemented,
-  # this is the only way to allow services to be looked up by their name, instead of the fully qualified domain name.
-  # On Kubernetes, this can be set to ".${NAMESPACE}.svc.cluster.local".
-  service-name-suffix = ""
 
   # The timeout for a successful lookup.
   lookup-timeout = 5 seconds

--- a/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/LookupBuilder.scala
+++ b/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/LookupBuilder.scala
@@ -7,35 +7,35 @@ package com.lightbend.lagom.internal.client
 import akka.discovery.Lookup
 
 /**
- * A copy of Lookup object from Akka.
- * This implementation is less restrictive with respect to the service name part in SRV string.
- * see https://github.com/akka/akka/pull/26332
- *
- * This can be removed and replaced by the Akka one when it gets merged and released.
- *
- */
+  * A copy of Lookup object from Akka.
+  * This implementation is less restrictive with respect to the service name part in SRV string.
+  * see https://github.com/akka/akka/pull/26332
+  *
+  * This can be removed and replaced by the Akka one when it gets merged and released.
+  *
+  */
 private[lagom] object LookupBuilder {
 
   /**
-   * Create a service Lookup with only a serviceName.
-   * Use withPortName and withProtocol to provide optional portName
-   * and protocol
-   */
+    * Create a service Lookup with only a serviceName.
+    * Use withPortName and withProtocol to provide optional portName
+    * and protocol
+    */
   def apply(serviceName: String): Lookup = new Lookup(serviceName, None, None)
 
   /**
-   * Create a service Lookup with `serviceName`, optional `portName` and optional `protocol`.
-   */
+    * Create a service Lookup with `serviceName`, optional `portName` and optional `protocol`.
+    */
   def apply(serviceName: String, portName: Option[String], protocol: Option[String]): Lookup =
     new Lookup(serviceName, portName, protocol)
 
   /**
-   * Java API
-   *
-   * Create a service Lookup with only a serviceName.
-   * Use withPortName and withProtocol to provide optional portName
-   * and protocol
-   */
+    * Java API
+    *
+    * Create a service Lookup with only a serviceName.
+    * Use withPortName and withProtocol to provide optional portName
+    * and protocol
+    */
   def create(serviceName: String): Lookup = new Lookup(serviceName, None, None)
 
   private val SrvQuery = """^_(.+?)\._(.+?)\.(.+?)$""".r
@@ -43,36 +43,38 @@ private[lagom] object LookupBuilder {
   private val ServiceName = "^[^.]([A-Za-z0-9-]\\.{0,1})+[^-_.]$".r
 
   /**
-   * Create a service Lookup from a string with format:
-   * _portName._protocol.serviceName.
-   * (as specified by https://www.ietf.org/rfc/rfc2782.txt)
-   *
-   * If the passed string conforms with this format, a SRV Lookup is returned.
-   * The serviceName part must be a valid domain name.
-   *
-   * The string is parsed and dismembered to build a Lookup as following:
-   * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
-   *
-   *
-   * @throws NullPointerException If the passed string is null
-   * @throws IllegalArgumentException If the string doesn't not conform with the SRV format
-   */
+    * Create a service Lookup from a string with format:
+    * _portName._protocol.serviceName.
+    * (as specified by https://www.ietf.org/rfc/rfc2782.txt)
+    *
+    * If the passed string conforms with this format, a SRV Lookup is returned.
+    * The serviceName part must be a valid domain name.
+    *
+    * The string is parsed and dismembered to build a Lookup as following:
+    * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
+    *
+    *
+    * @throws NullPointerException If the passed string is null
+    * @throws IllegalArgumentException If the string doesn't not conform with the SRV format
+    */
   def parseSrv(str: String): Lookup =
     str match {
       case SrvQuery(portName, protocol, serviceName) if validServiceName(serviceName) ⇒
         Lookup(serviceName).withPortName(portName).withProtocol(protocol)
 
-      case null ⇒ throw new NullPointerException("Unable to create Lookup from passed SRV string. Passed value is 'null'")
-      case _    ⇒ throw new IllegalArgumentException(s"Unable to create Lookup from passed SRV string, invalid format: $str")
+      case null ⇒
+        throw new NullPointerException("Unable to create Lookup from passed SRV string. Passed value is 'null'")
+      case _ ⇒
+        throw new IllegalArgumentException(s"Unable to create Lookup from passed SRV string, invalid format: $str")
     }
 
   /**
-   * Returns true if passed string conforms with SRV format. Otherwise returns false.
-   */
+    * Returns true if passed string conforms with SRV format. Otherwise returns false.
+    */
   def isValidSrv(srv: String): Boolean =
     srv match {
       case SrvQuery(_, _, serviceName) ⇒ validServiceName(serviceName)
-      case _                           ⇒ false
+      case _ ⇒ false
     }
 
   private def validServiceName(name: String): Boolean =

--- a/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/LookupBuilder.scala
+++ b/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/LookupBuilder.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package com.lightbend.lagom.internal.client
 
 import akka.discovery.Lookup

--- a/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/LookupBuilder.scala
+++ b/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/LookupBuilder.scala
@@ -1,0 +1,77 @@
+package com.lightbend.lagom.internal.client
+
+import akka.discovery.Lookup
+
+/**
+ * A copy of Lookup object from Akka.
+ * This implementation is less restrictive with respect to the service name part in SRV string.
+ * see https://github.com/akka/akka/pull/26332
+ *
+ * This can be removed and replaced by the Akka one when it gets merged and released.
+ *
+ */
+private[lagom] object LookupBuilder {
+
+  /**
+   * Create a service Lookup with only a serviceName.
+   * Use withPortName and withProtocol to provide optional portName
+   * and protocol
+   */
+  def apply(serviceName: String): Lookup = new Lookup(serviceName, None, None)
+
+  /**
+   * Create a service Lookup with `serviceName`, optional `portName` and optional `protocol`.
+   */
+  def apply(serviceName: String, portName: Option[String], protocol: Option[String]): Lookup =
+    new Lookup(serviceName, portName, protocol)
+
+  /**
+   * Java API
+   *
+   * Create a service Lookup with only a serviceName.
+   * Use withPortName and withProtocol to provide optional portName
+   * and protocol
+   */
+  def create(serviceName: String): Lookup = new Lookup(serviceName, None, None)
+
+  private val SrvQuery = """^_(.+?)\._(.+?)\.(.+?)$""".r
+
+  private val ServiceName = "^[^.]([A-Za-z0-9-]\\.{0,1})+[^-_.]$".r
+
+  /**
+   * Create a service Lookup from a string with format:
+   * _portName._protocol.serviceName.
+   * (as specified by https://www.ietf.org/rfc/rfc2782.txt)
+   *
+   * If the passed string conforms with this format, a SRV Lookup is returned.
+   * The serviceName part must be a valid domain name.
+   *
+   * The string is parsed and dismembered to build a Lookup as following:
+   * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
+   *
+   *
+   * @throws NullPointerException If the passed string is null
+   * @throws IllegalArgumentException If the string doesn't not conform with the SRV format
+   */
+  def parseSrv(str: String): Lookup =
+    str match {
+      case SrvQuery(portName, protocol, serviceName) if validServiceName(serviceName) ⇒
+        Lookup(serviceName).withPortName(portName).withProtocol(protocol)
+
+      case null ⇒ throw new NullPointerException("Unable to create Lookup from passed SRV string. Passed value is 'null'")
+      case _    ⇒ throw new IllegalArgumentException(s"Unable to create Lookup from passed SRV string, invalid format: $str")
+    }
+
+  /**
+   * Returns true if passed string conforms with SRV format. Otherwise returns false.
+   */
+  def isValidSrv(srv: String): Boolean =
+    srv match {
+      case SrvQuery(_, _, serviceName) ⇒ validServiceName(serviceName)
+      case _                           ⇒ false
+    }
+
+  private def validServiceName(name: String): Boolean =
+    ServiceName.pattern.asPredicate().test(name)
+
+}

--- a/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
+++ b/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
@@ -17,7 +17,6 @@ import scala.collection.JavaConverters._
 private[lagom] class ServiceNameMapper(config: Config) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-
   private val defaultPortName = Some(config.getString("defaults.port-name")).filter(_.nonEmpty)
   private val defaultPortProtocol = Some(config.getString("defaults.port-protocol")).filter(_.nonEmpty)
   private val defaultScheme = Some(config.getString("defaults.scheme")).filter(_.nonEmpty)
@@ -68,8 +67,6 @@ private[lagom] class ServiceNameMapper(config: Config) {
   }
 }
 
-private[lagom] case class ServiceNameMapping(name: String,
-                                             lookup: Option[String],
-                                             scheme: Option[String])
+private[lagom] case class ServiceNameMapping(name: String, lookup: Option[String], scheme: Option[String])
 
 private[lagom] case class ServiceLookup(lookup: Lookup, scheme: Option[String])

--- a/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
+++ b/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
@@ -17,95 +17,51 @@ import scala.collection.JavaConverters._
 private[lagom] class ServiceNameMapper(config: Config) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private val serviceLookupRegex = Some(config.getString("service-lookup-regex"))
-    .filter(_.nonEmpty)
-    .map(Pattern.compile)
 
   private val defaultPortName = Some(config.getString("defaults.port-name")).filter(_.nonEmpty)
   private val defaultPortProtocol = Some(config.getString("defaults.port-protocol")).filter(_.nonEmpty)
-  private val serviceNameSuffix = config.getString("service-name-suffix")
-
-  private val portNameSchemeMapping = {
-    val mappings = config.getConfig("port-name-scheme-mapping")
-    config
-      .getObject("port-name-scheme-mapping")
-      .asScala
-      .map {
-        case (key, _) => key -> mappings.getString(key)
-      }
-      .toMap
-  }
   private val defaultScheme = Some(config.getString("defaults.scheme")).filter(_.nonEmpty)
 
-  private val serviceLookupMapping = config
-    .getObject("service-name-mappings")
-    .entrySet()
-    .asScala
-    .map { entry =>
-      if (entry.getValue.valueType != ConfigValueType.OBJECT) {
-        throw new IllegalArgumentException(
-          s"Illegal value type in service-name-mappings: ${entry.getKey} - ${entry.getValue.valueType}")
+  private val serviceLookupMapping: Map[String, ServiceLookup] =
+    config
+      .getObject("service-name-mappings")
+      .entrySet()
+      .asScala
+      .map { entry =>
+        if (entry.getValue.valueType != ConfigValueType.OBJECT) {
+          throw new IllegalArgumentException(
+            s"Illegal value type in service-name-mappings: ${entry.getKey} - ${entry.getValue.valueType}")
+        }
+        val configEntry = entry.getValue.asInstanceOf[ConfigObject].toConfig
+
+        def getOptionString(name: String) =
+          if (configEntry.hasPath(name)) Some(configEntry.getString(name))
+          else None
+
+        val lookup: Lookup =
+          getOptionString("lookup")
+            .map(parseSrv)
+            .getOrElse(Lookup(entry.getKey, defaultPortName, defaultPortProtocol))
+
+        val scheme = getOptionString("scheme").orElse(defaultScheme)
+
+        entry.getKey -> ServiceLookup(lookup, scheme)
       }
-      val c = entry.getValue.asInstanceOf[ConfigObject].toConfig
+      .toMap
 
-      def get(name: String) = if (c.hasPath(name)) Some(c.getString(name)) else None
-
-      val serviceName = get("service-name").getOrElse(entry.getKey) + serviceNameSuffix
-      val portName = get("port-name").orElse(defaultPortName)
-      val portProtocol = get("port-protocol").orElse(defaultPortProtocol)
-      val scheme = get("scheme")
-        .orElse(portName.flatMap(portNameSchemeMapping.get))
-        .orElse(defaultScheme)
-      entry.getKey -> ServiceNameMapping(entry.getKey, serviceName, portName, portProtocol, scheme)
-    }
-    .toMap
+  private[lagom] def parseSrv(name: String) =
+    if (LookupBuilder.isValidSrv(name)) LookupBuilder.parseSrv(name)
+    else Lookup(name, defaultPortName, defaultPortProtocol)
 
   private[lagom] def mapLookupQuery(name: String): ServiceLookup = {
-    // First attempt to construct lookup using configured mappings
-    val serviceLookup = serviceLookupMapping.get(name) match {
-      case Some(mapping) =>
-        ServiceLookup(Lookup(mapping.serviceName, mapping.portName, mapping.portProtocol), mapping.scheme)
-
-      case None =>
-        // Next attempt to construct lookup using the service lookup regex
-        val lookup = serviceLookupRegex match {
-          case Some(pattern) =>
-            val matcher = pattern.matcher(name)
-            if (matcher.matches()) {
-              val serviceName = matcher.group("service")
-              if (serviceName == null || serviceName.isEmpty) {
-                throw new IllegalArgumentException(
-                  "Service lookup regex did not contain a named capturing group called " +
-                    "'service', or that group matched an empty string.")
-              }
-
-              def groupOrElse(group: String, default: Option[String]) =
-                Option(matcher.group(group)).filter(_.nonEmpty).orElse(default)
-
-              Lookup(
-                serviceName + serviceNameSuffix,
-                groupOrElse("portName", defaultPortName),
-                groupOrElse("portProtocol", defaultPortProtocol)
-              )
-            } else {
-              Lookup(name + serviceNameSuffix, defaultPortName, defaultPortProtocol)
-            }
-          case None => Lookup(name + serviceNameSuffix, defaultPortName, defaultPortProtocol)
-
-        }
-
-        ServiceLookup(lookup, lookup.portName.flatMap(portNameSchemeMapping.get).orElse(defaultScheme))
-    }
-
+    val serviceLookup = serviceLookupMapping.getOrElse(name, ServiceLookup(parseSrv(name), defaultScheme))
     logger.debug("Lookup service '{}', mapped to {}", name: Any, serviceLookup: Any)
     serviceLookup
   }
 }
 
 private[lagom] case class ServiceNameMapping(name: String,
-                                             serviceName: String,
-                                             portName: Option[String],
-                                             portProtocol: Option[String],
+                                             lookup: Option[String],
                                              scheme: Option[String])
 
 private[lagom] case class ServiceLookup(lookup: Lookup, scheme: Option[String])

--- a/service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
+++ b/service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
@@ -4,6 +4,7 @@
 
 package com.lightbend.lagom.internal.client
 
+import akka.discovery.Lookup
 import com.typesafe.config.ConfigFactory
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
@@ -12,108 +13,111 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
 
   private val defaultConfig = ConfigFactory.defaultReference().getConfig("lagom.akka.discovery")
   private val parser = new ServiceNameMapper(defaultConfig)
+
+  val defaultPortName = Some("http")
+  val defaultProtocol = Some("tcp")
+  val defaultScheme = Some("tcp")
+
   private def createParser(config: String) =
     new ServiceNameMapper(ConfigFactory.parseString(config).withFallback(defaultConfig))
 
-  "The ServiceNameParser" should {
+  "The ServiceNameMapper" should {
 
-    "parse an unqualified Kubernetes SRV lookup" in {
-      val serviceLookup = parser.mapLookupQuery("_fooname._fooprotocol.myservice")
-      val lookup = serviceLookup.lookup
-      lookup.serviceName should be("myservice")
-      lookup.portName should be(Some("fooname"))
-      lookup.protocol should be(Some("fooprotocol"))
-      serviceLookup.scheme should be(Some("tcp"))
+    // ------------------------------------------------------------------------------
+    // Assert SRV lookups
+    "parse an unqualified SRV lookup" in {
+      val lookup = parser.mapLookupQuery("_fooname._fooprotocol.myservice").lookup
+      lookup shouldBe Lookup("myservice", Some("fooname"), Some("fooprotocol"))
     }
 
-    "parse a fully qualified Kubernetes SRV lookup" in {
+    "parse a fully-qualified SRV lookup" in {
       val lookup = parser.mapLookupQuery("_fooname._fooprotocol.myservice.mynamespace.svc.cluster.local").lookup
-      lookup.serviceName should be("myservice.mynamespace.svc.cluster.local")
-      lookup.portName should be(Some("fooname"))
-      lookup.protocol should be(Some("fooprotocol"))
+      lookup shouldBe Lookup("myservice.mynamespace.svc.cluster.local", Some("fooname"), Some("fooprotocol"))
     }
 
-    "parse an unqualified Kubernetes service name" in {
-      val serviceLookup = parser.mapLookupQuery("myservice")
-      val lookup = serviceLookup.lookup
-      lookup.serviceName should be("myservice")
-      lookup.portName should be(Some("http"))
-      lookup.protocol should be(Some("tcp"))
-      serviceLookup.scheme should be(Some("http"))
+
+    // ------------------------------------------------------------------------------
+    // Assert simple Service Name lookup
+    "parse an unqualified service name" in {
+      val lookup = parser.mapLookupQuery("myservice").lookup
+      lookup shouldBe Lookup("myservice", defaultPortName, defaultProtocol)
     }
 
-    "parse an fully qualified Kubernetes service name" in {
+    "parse an fully-qualified service name" in {
       val lookup = parser.mapLookupQuery("myservice.mynamespace.svc.cluster.local").lookup
-      lookup.serviceName should be("myservice.mynamespace.svc.cluster.local")
-      lookup.portName should be(Some("http"))
-      lookup.protocol should be(Some("tcp"))
+      lookup shouldBe Lookup("myservice.mynamespace.svc.cluster.local", defaultPortName, defaultProtocol)
     }
 
+
+    // ------------------------------------------------------------------------------
+    // Assert blank defaults
     "not include default port name if not specified" in {
-      val lookup = createParser("""defaults.port-name = "" """).mapLookupQuery("myservice").lookup
-      lookup.serviceName should be("myservice")
-      lookup.portName should be(None)
-      lookup.protocol should be(Some("tcp"))
+      val customParser = createParser("""defaults.port-name = "" """)
+      val lookup = customParser.mapLookupQuery("myservice").lookup
+      lookup shouldBe Lookup("myservice", None, defaultProtocol)
     }
 
     "not include default port protocol if not specified" in {
-      val lookup = createParser("""defaults.port-protocol = "" """).mapLookupQuery("myservice").lookup
-      lookup.serviceName should be("myservice")
-      lookup.portName should be(Some("http"))
-      lookup.protocol should be(None)
+      val customParser = createParser("""defaults.port-protocol = "" """)
+      val lookup = customParser.mapLookupQuery("myservice").lookup
+      lookup shouldBe Lookup("myservice", defaultPortName, None)
     }
 
-    "not attempt to parse the string if regex isn't specified" in {
-      val lookup = createParser("""service-lookup-regex = "" """)
-        .mapLookupQuery("_fooname._fooprotocol.myservice")
-        .lookup
-      lookup.serviceName should be("_fooname._fooprotocol.myservice")
-      lookup.portName should be(Some("http"))
-      lookup.protocol should be(Some("tcp"))
-    }
 
-    "include a suffix if configured" in {
-      createParser("service-name-suffix = .mynamespace.svc.cluster.local")
-        .mapLookupQuery("myservice")
-        .lookup
-        .serviceName should be("myservice.mynamespace.svc.cluster.local")
-    }
-
+    // ------------------------------------------------------------------------------
+    // Assert custom mappings
     "return a mapped service name" in {
-      val lookup = createParser("service-name-mappings.myservice.service-name = mappedmyservice")
-        .mapLookupQuery("myservice")
-        .lookup
-      lookup.serviceName should be("mappedmyservice")
-      lookup.portName should be(Some("http"))
-      lookup.protocol should be(Some("tcp"))
+      val customParser = createParser("service-name-mappings.myservice.lookup = mappedmyservice")
+      val lookup = customParser.mapLookupQuery("myservice").lookup
+      lookup shouldBe Lookup("mappedmyservice", defaultPortName, defaultProtocol)
     }
 
     "return a mapped port name" in {
-      val serviceLookup = createParser("service-name-mappings.myservice.port-name = remoting")
-        .mapLookupQuery("myservice")
-      val lookup = serviceLookup.lookup
-      lookup.serviceName should be("myservice")
-      lookup.portName should be(Some("remoting"))
-      lookup.protocol should be(Some("tcp"))
-      serviceLookup.scheme should be(Some("tcp"))
+      val customParser = createParser("service-name-mappings.myservice.lookup = _remoting._udp.mappedmyservice")
+      val lookup = customParser.mapLookupQuery("myservice").lookup
+      lookup shouldBe Lookup("mappedmyservice", Some("remoting"), Some("udp"))
     }
 
-    "return a mapped port protocol" in {
-      val lookup = createParser("service-name-mappings.myservice.port-protocol = udp")
-        .mapLookupQuery("myservice")
-        .lookup
-      lookup.serviceName should be("myservice")
-      lookup.portName should be(Some("http"))
-      lookup.protocol should be(Some("udp"))
+
+    // ------------------------------------------------------------------------------
+    // Assert Schema mapping
+    "return a default scheme if not specified" in {
+      val serviceLookup = parser.mapLookupQuery("myservice")
+      serviceLookup.scheme should be(defaultScheme)
+    }
+
+    "not include default scheme if not specified" in {
+      val customParser = createParser("""defaults.scheme = "" """)
+      val serviceLookup = customParser.mapLookupQuery("myservice")
+      serviceLookup.scheme should be(None)
+    }
+
+    "return a mapped schema for a mapped SVR"  in {
+      val customParser = createParser(
+        """
+          |service-name-mappings.myservice {
+          |  lookup = _remoting._udp.mappedmyservice
+          |  scheme = bar
+          |}
+        """.stripMargin)
+      val serviceLookup = customParser.mapLookupQuery("myservice")
+      serviceLookup.scheme should be(Some("bar"))
+    }
+
+    "return a default schema for a mapped SVR"  in {
+      val customParser = createParser(
+        """
+          |service-name-mappings.myservice {
+          |  lookup = _remoting._udp.mappedmyservice
+          |}
+        """.stripMargin)
+      val serviceLookup = customParser.mapLookupQuery("myservice")
+      serviceLookup.scheme should be(defaultScheme)
     }
 
     "return a mapped scheme" in {
-      val serviceLookup = createParser("service-name-mappings.myservice.scheme = foo")
-        .mapLookupQuery("myservice")
-      val lookup = serviceLookup.lookup
-      lookup.serviceName should be("myservice")
-      lookup.portName should be(Some("http"))
-      lookup.protocol should be(Some("tcp"))
+      val customParser = createParser("service-name-mappings.myservice.scheme = foo")
+      val serviceLookup = customParser.mapLookupQuery("myservice")
       serviceLookup.scheme should be(Some("foo"))
     }
 

--- a/service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
+++ b/service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
@@ -51,13 +51,13 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
 
     // ------------------------------------------------------------------------------
     // Assert blank defaults
-    "not include default port name if not specified" in {
+    "not include default port name if defaults.port-name is blank" in {
       val customParser = createParser("""defaults.port-name = "" """)
       val lookup = customParser.mapLookupQuery("myservice").lookup
       lookup shouldBe Lookup("myservice", None, defaultProtocol)
     }
 
-    "not include default port protocol if not specified" in {
+    "not include default port protocol if defaults.port-protocol is blank" in {
       val customParser = createParser("""defaults.port-protocol = "" """)
       val lookup = customParser.mapLookupQuery("myservice").lookup
       lookup shouldBe Lookup("myservice", defaultPortName, None)
@@ -86,8 +86,20 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       serviceLookup.scheme should be(defaultScheme)
     }
 
-    "not include default scheme if not specified" in {
+    "not include default scheme if defaults.scheme is blank" in {
       val customParser = createParser("""defaults.scheme = "" """)
+      val serviceLookup = customParser.mapLookupQuery("myservice")
+      serviceLookup.scheme should be(None)
+    }
+
+    "not include scheme if service-name-mappings.myservice.scheme is blank" in {
+      val customParser = createParser(
+        """
+          |service-name-mappings.myservice {
+          |  lookup = _remoting._udp.mappedmyservice
+          |  scheme = ""
+          |}
+        """.stripMargin)
       val serviceLookup = customParser.mapLookupQuery("myservice")
       serviceLookup.scheme should be(None)
     }

--- a/service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
+++ b/service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
@@ -35,7 +35,6 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       lookup shouldBe Lookup("myservice.mynamespace.svc.cluster.local", Some("fooname"), Some("fooprotocol"))
     }
 
-
     // ------------------------------------------------------------------------------
     // Assert simple Service Name lookup
     "parse an unqualified service name" in {
@@ -47,7 +46,6 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       val lookup = parser.mapLookupQuery("myservice.mynamespace.svc.cluster.local").lookup
       lookup shouldBe Lookup("myservice.mynamespace.svc.cluster.local", defaultPortName, defaultProtocol)
     }
-
 
     // ------------------------------------------------------------------------------
     // Assert blank defaults
@@ -63,7 +61,6 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       lookup shouldBe Lookup("myservice", defaultPortName, None)
     }
 
-
     // ------------------------------------------------------------------------------
     // Assert custom mappings
     "return a mapped service name" in {
@@ -77,7 +74,6 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       val lookup = customParser.mapLookupQuery("myservice").lookup
       lookup shouldBe Lookup("mappedmyservice", Some("remoting"), Some("udp"))
     }
-
 
     // ------------------------------------------------------------------------------
     // Assert Schema mapping
@@ -93,8 +89,7 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
     }
 
     "not include scheme if service-name-mappings.myservice.scheme is blank" in {
-      val customParser = createParser(
-        """
+      val customParser = createParser("""
           |service-name-mappings.myservice {
           |  lookup = _remoting._udp.mappedmyservice
           |  scheme = ""
@@ -104,9 +99,8 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       serviceLookup.scheme should be(None)
     }
 
-    "return a mapped schema for a mapped SVR"  in {
-      val customParser = createParser(
-        """
+    "return a mapped schema for a mapped SVR" in {
+      val customParser = createParser("""
           |service-name-mappings.myservice {
           |  lookup = _remoting._udp.mappedmyservice
           |  scheme = bar
@@ -116,9 +110,8 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       serviceLookup.scheme should be(Some("bar"))
     }
 
-    "return a default schema for a mapped SVR"  in {
-      val customParser = createParser(
-        """
+    "return a default schema for a mapped SVR" in {
+      val customParser = createParser("""
           |service-name-mappings.myservice {
           |  lookup = _remoting._udp.mappedmyservice
           |}


### PR DESCRIPTION
* drops port-name to schema mapping, either user default or explicit scheme
 * drops custom port-name and protocol, instead favor SVR format 

Resolves #26