### PR TITLE
Mergify to check new Travis CI check

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@
 pull_request_rules:
   - name: Merge PRs that are ready
     conditions:
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=Travis CI - Pull Request
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "#review-requested=0"


### PR DESCRIPTION
Mergify was checking the old travis pr url.