### PR TITLE
Add support for unset config using null

### DIFF
--- a/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
+++ b/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
@@ -17,9 +17,33 @@ import scala.collection.JavaConverters._
 private[lagom] class ServiceNameMapper(config: Config) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private val defaultPortName = Some(config.getString("defaults.port-name")).filter(_.nonEmpty)
-  private val defaultPortProtocol = Some(config.getString("defaults.port-protocol")).filter(_.nonEmpty)
-  private val defaultScheme = Some(config.getString("defaults.scheme")).filter(_.nonEmpty)
+  private val defaultPortName = readConfigValue(config, "defaults.port-name").toOption
+  private val defaultPortProtocol = readConfigValue(config, "defaults.port-protocol").toOption
+  private val defaultScheme = readConfigValue(config, "defaults.scheme").toOption
+
+  sealed trait ConfigValue {
+    def toOption =
+      this match {
+        case NonEmpty(v) => Some(v)
+        case _ => None
+      }
+  }
+  object ConfigValue {
+    def apply(value: String) =
+     if (value.trim.isEmpty) Empty
+     else NonEmpty(value.trim)
+  }
+  case object Undefined extends ConfigValue
+  case object Empty extends ConfigValue
+  case class NonEmpty(value: String) extends ConfigValue
+
+  private[lagom] def readConfigValue(config: Config, name: String) = {
+    if (config.hasPathOrNull(name)) {
+      if (config.getIsNull(name)) Empty
+      else ConfigValue(config.getString(name))
+    }
+    else Undefined
+  }
 
   private val serviceLookupMapping: Map[String, ServiceLookup] =
     config
@@ -33,23 +57,20 @@ private[lagom] class ServiceNameMapper(config: Config) {
         }
         val configEntry = entry.getValue.asInstanceOf[ConfigObject].toConfig
 
-        def getOptionString(name: String) =
-          if (configEntry.hasPath(name)) Some(configEntry.getString(name).trim)
-          else None
 
         val lookup: Lookup =
-          getOptionString("lookup")
+          readConfigValue(configEntry, "lookup").toOption
             .map(parseSrv)
             .getOrElse(Lookup(entry.getKey, defaultPortName, defaultPortProtocol))
 
         // if the user didn't explicitly set a value, use the default scheme,
         // otherwise honour user settings.
         val scheme =
-          getOptionString("scheme") match {
-            case None => defaultScheme
+          readConfigValue(configEntry, "scheme") match {
+            case Undefined => defaultScheme
             // this is the case the user explicitly set the scheme to empty string
-            case Some("") => None
-            case anyOther => anyOther
+            case Empty => None
+            case NonEmpty(value) => Option(value)
           }
 
         entry.getKey -> ServiceLookup(lookup, scheme)

--- a/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
+++ b/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
@@ -21,29 +21,27 @@ private[lagom] class ServiceNameMapper(config: Config) {
   private val defaultPortProtocol = readConfigValue(config, "defaults.port-protocol").toOption
   private val defaultScheme = readConfigValue(config, "defaults.scheme").toOption
 
-  private sealed trait ConfigValue {
+  sealed private trait ConfigValue {
     def toOption =
       this match {
         case NonEmpty(v) => Some(v)
-        case _ => None
+        case _           => None
       }
   }
   private object ConfigValue {
     def apply(value: String) =
-     if (value.trim.isEmpty) Empty
-     else NonEmpty(value.trim)
+      if (value.trim.isEmpty) Empty
+      else NonEmpty(value.trim)
   }
   private case object Undefined extends ConfigValue
   private case object Empty extends ConfigValue
   private case class NonEmpty(value: String) extends ConfigValue
 
-  private def readConfigValue(config: Config, name: String) = {
+  private def readConfigValue(config: Config, name: String) =
     if (config.hasPathOrNull(name)) {
       if (config.getIsNull(name)) Empty
       else ConfigValue(config.getString(name))
-    }
-    else Undefined
-  }
+    } else Undefined
 
   private val serviceLookupMapping: Map[String, ServiceLookup] =
     config
@@ -57,7 +55,6 @@ private[lagom] class ServiceNameMapper(config: Config) {
         }
         val configEntry = entry.getValue.asInstanceOf[ConfigObject].toConfig
 
-
         val lookup: Lookup =
           readConfigValue(configEntry, "lookup").toOption
             .map(parseSrv)
@@ -69,7 +66,7 @@ private[lagom] class ServiceNameMapper(config: Config) {
           readConfigValue(configEntry, "scheme") match {
             case Undefined => defaultScheme
             // this is the case the user explicitly set the scheme to empty string
-            case Empty => None
+            case Empty           => None
             case NonEmpty(value) => Option(value)
           }
 

--- a/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
+++ b/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
@@ -21,23 +21,23 @@ private[lagom] class ServiceNameMapper(config: Config) {
   private val defaultPortProtocol = readConfigValue(config, "defaults.port-protocol").toOption
   private val defaultScheme = readConfigValue(config, "defaults.scheme").toOption
 
-  sealed trait ConfigValue {
+  private sealed trait ConfigValue {
     def toOption =
       this match {
         case NonEmpty(v) => Some(v)
         case _ => None
       }
   }
-  object ConfigValue {
+  private object ConfigValue {
     def apply(value: String) =
      if (value.trim.isEmpty) Empty
      else NonEmpty(value.trim)
   }
-  case object Undefined extends ConfigValue
-  case object Empty extends ConfigValue
-  case class NonEmpty(value: String) extends ConfigValue
+  private case object Undefined extends ConfigValue
+  private case object Empty extends ConfigValue
+  private case class NonEmpty(value: String) extends ConfigValue
 
-  private[lagom] def readConfigValue(config: Config, name: String) = {
+  private def readConfigValue(config: Config, name: String) = {
     if (config.hasPathOrNull(name)) {
       if (config.getIsNull(name)) Empty
       else ConfigValue(config.getString(name))
@@ -77,7 +77,7 @@ private[lagom] class ServiceNameMapper(config: Config) {
       }
       .toMap
 
-  private[lagom] def parseSrv(name: String) =
+  private def parseSrv(name: String) =
     if (LookupBuilder.isValidSrv(name)) LookupBuilder.parseSrv(name)
     else Lookup(name, defaultPortName, defaultPortProtocol)
 

--- a/service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
+++ b/service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
@@ -55,8 +55,20 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       lookup shouldBe Lookup("myservice", None, defaultProtocol)
     }
 
+    "not include default port name if defaults.port-name is null" in {
+      val customParser = createParser("""defaults.port-name = null """)
+      val lookup = customParser.mapLookupQuery("myservice").lookup
+      lookup shouldBe Lookup("myservice", None, defaultProtocol)
+    }
+
     "not include default port protocol if defaults.port-protocol is blank" in {
       val customParser = createParser("""defaults.port-protocol = "" """)
+      val lookup = customParser.mapLookupQuery("myservice").lookup
+      lookup shouldBe Lookup("myservice", defaultPortName, None)
+    }
+
+    "not include default port protocol if defaults.port-protocol is null" in {
+      val customParser = createParser("""defaults.port-protocol = null """)
       val lookup = customParser.mapLookupQuery("myservice").lookup
       lookup shouldBe Lookup("myservice", defaultPortName, None)
     }
@@ -88,11 +100,28 @@ class ServiceNameMapperSpec extends WordSpec with Matchers {
       serviceLookup.scheme should be(None)
     }
 
+    "not include default scheme if defaults.scheme is null" in {
+      val customParser = createParser("""defaults.scheme = null """)
+      val serviceLookup = customParser.mapLookupQuery("myservice")
+      serviceLookup.scheme should be(None)
+    }
+
     "not include scheme if service-name-mappings.myservice.scheme is blank" in {
       val customParser = createParser("""
           |service-name-mappings.myservice {
           |  lookup = _remoting._udp.mappedmyservice
           |  scheme = ""
+          |}
+        """.stripMargin)
+      val serviceLookup = customParser.mapLookupQuery("myservice")
+      serviceLookup.scheme should be(None)
+    }
+
+    "not include scheme if service-name-mappings.myservice.scheme is null" in {
+      val customParser = createParser("""
+          |service-name-mappings.myservice {
+          |  lookup = _remoting._udp.mappedmyservice
+          |  scheme = null
           |}
         """.stripMargin)
       val serviceLookup = customParser.mapLookupQuery("myservice")


### PR DESCRIPTION
Introduces an internal type: `ConfigValue`. 

A `ConfigValue` can be:

* `Undefined` - when it was never set by the user
* `Empty` - when the user set it to null or ""  
* `NonEmpty` - when the user set it to a non-empty string

We only fallback to default values when we read it as `Undefined`. 
`Empty` are mapped to `None` and `NonEmpty` mapped to `Some`

Relates to: https://github.com/lagom/lagom-akka-discovery-service-locator/pull/29#discussion_r253890117